### PR TITLE
Update docs - remove reference to storing data

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # CAVE
 
-CAVE, the Continuous Audit Vault Enterprise, is designed to store your mission critical data and alert you when things are not what they should be. In a nutshell, the CAVE customer pumps metric data into CAVE and receives notifications about events that are detected in this data.
+CAVE, the Continuous Audit Vault Enterprise, is designed to analyze your mission critical data and alert you when things are not what they should be. In a nutshell, the CAVE customer pumps metric data into CAVE and receives notifications about events that are detected in this data.
 
 ## Getting Started
 See [this page](getting-started.md).


### PR DESCRIPTION
I don't think docs should say that CAVE is designed to store mission critical data.