### PR TITLE
Allow creation of alerts specified as a time of day

### DIFF
--- a/core/src/main/scala/com/cave/metrics/data/AlertManager.scala
+++ b/core/src/main/scala/com/cave/metrics/data/AlertManager.scala
@@ -71,7 +71,7 @@ class AlertManager(dataManager: DataManager, influxClientFactory: InfluxClientFa
     val clusterName = team map(_.influxCluster) getOrElse organization.influxCluster
     implicit val (client, context) = influxClientFactory.getClient(clusterName)
 
-    parseAll(duration, alert.period) match {
+    parseAll(anyPeriod, alert.period) match {
       case Success(_, _) =>
         parseAll(anyAlert, alert.condition) match {
           case Success(SimpleAlert(left, _, right, _, _), _) =>

--- a/core/src/main/scala/com/cave/metrics/data/evaluator/AlertParser.scala
+++ b/core/src/main/scala/com/cave/metrics/data/evaluator/AlertParser.scala
@@ -113,6 +113,8 @@ trait AlertParser extends JavaTokenParsers {
 
   def daily: Parser[LocalTime] = dailySeconds | dailyMinutes | dailyHours
 
+  def anyPeriod = duration | daily
+
   def repeater: Parser[Int] = "at least" ~> wholeNumber <~ "times" ^^ {
     case num => num.toInt
   }

--- a/core/src/test/scala/com/cave/metrics/data/AlertManagerSpec.scala
+++ b/core/src/test/scala/com/cave/metrics/data/AlertManagerSpec.scala
@@ -96,6 +96,17 @@ class AlertManagerSpec extends AbstractDataManagerSpec with MockitoSugar {
     }
   }
 
+  it should "correctly parse alert with time-of-day daily period" in {
+    val org = dm.getOrganization(GiltOrgName).get.get
+
+    am.createOrganizationAlert(org, Alert(None, "alert description", true, "@12:34", "orders[].sum.10m >= 10", None, None)) match {
+      case Success(Some(alert)) =>
+        alert.id.isDefined should be(true)
+
+      case _ => fail("Expected alert creation to succeed")
+    }
+  }
+
   it should "add metrics to the alerts when fetching" in {
     val org = dm.getOrganization(GiltOrgName).get.get
     val team = dm.getTeam(org, testTeamName).get.get

--- a/core/src/test/scala/com/cave/metrics/data/AlertParserSpec.scala
+++ b/core/src/test/scala/com/cave/metrics/data/AlertParserSpec.scala
@@ -1,6 +1,7 @@
 package com.cave.metrics.data
 
 import com.cave.metrics.data.evaluator.{Aggregator, AlertParser}
+import org.joda.time.LocalTime
 
 import scala.concurrent.duration._
 import org.scalatest._
@@ -377,6 +378,29 @@ class AlertParserSpec extends FlatSpec with Matchers with AlertParser with Alert
         timeOfDay.getMinuteOfHour should be (25)
         timeOfDay.getSecondOfMinute should be (36)
         timeOfDay.getMillisOfSecond should be (0)
+
+      case _ => fail("Expected a LocalTime to be parsed")
+    }
+  }
+
+  "An alert period" should "be specified as a duration" in {
+    parseAll(anyPeriod, "1m") match {
+      case Success(duration, _) =>
+        duration should be (1.minutes)
+
+      case _ => fail("Expected a duration to be parsed")
+    }
+  }
+
+  it should "be parsed as a fixed time as well" in {
+    parseAll(anyPeriod, "@13:00") match {
+      case Success(period, _) =>
+        period shouldBe a[LocalTime]
+        val localTime = period.asInstanceOf[LocalTime]
+        localTime.getHourOfDay should be (13)
+        localTime.getMinuteOfHour should be (0)
+        localTime.getSecondOfMinute should be (0)
+        localTime.getMillisOfSecond should be (0)
 
       case _ => fail("Expected a LocalTime to be parsed")
     }

--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -8,7 +8,10 @@ Next, __a description__. This is a string that should describe what the alert is
 * _"No heartbeat received from svc-important for 5 minutes"_
 * _"The 5 minutes p99 of Response Time for svc-important is above SLA of 1.5 seconds for more than 15 minutes"_.
 
-Also, __a period__. This tells CAVE how often to evaluate the _condition_. This is expressed as a number followed by a letter: `s` for seconds, `m` for minutes, `h` for hours, or `d` for days. For example, a value of `5m` means `5 minutes`.
+Also, __a period__. This tells CAVE how often to evaluate the _condition_. This can be expressed in one of two ways.
+
+* To specify the period between each evaluation use a number followed by a letter: `s` for seconds, `m` for minutes, `h` for hours, or `d` for days. For example, a value of `5m` means `Evaluate every 5 minutes`.
+* To specify a particular time every day when the alert should be evaluated use @hh:mm:ss. For example  `@13:30:00` means `Evaluate every day at 13:30:00 UTC`
 
 Next, a boolean value for __enabled__. A value of `false` for this flag allows an alert to be defined, but not evaluated. If `true`, the alert is evaluated periodically, with the specified _period_.
 


### PR DESCRIPTION
The scheduler already attempts to parse periods as either a duration
or a daily period. Now the validation when creating an alert will
also accept daily periods

Closes #21